### PR TITLE
Make the travis build work. Build CLI and Web-Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,35 @@
-language: haskell
+env:
+ - GHCVER=7.8.2
 
-install: "cd Magic && cabal install --only-dependencies --enable-tests"
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-1.18 ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/1.18/bin:$PATH
+
+install:
+ - cd Magic-CLI
+ - cabal sandbox init
+ - cabal sandbox add-source ../Magic
+ - cabal sandbox add-source ../Magic-Cards
+ - cabal update
+ - cabal install --dependencies-only
+
+ - cd ../Magic-Web-Server
+ - cabal sandbox init
+ - cabal sandbox add-source ../Magic
+ - cabal sandbox add-source ../Magic-Cards
+ - cabal update
+ - cabal install --dependencies-only
+
+
+# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - cd ../Magic-CLI
+ - cabal configure
+ - cabal build
+
+ - cd ../Magic-Web-Server
+ - cabal configure
+ - cabal build
+


### PR DESCRIPTION
Fixes the travis build using @hvr's [multi-ghc-travis](https://github.com/hvr/multi-ghc-travis) template, but only for ghc 7.8.
