### PR TITLE
Add card 'Ravenous Rats'

### DIFF
--- a/Magic-Cards/src/Magic/M13.hs
+++ b/Magic-Cards/src/Magic/M13.hs
@@ -514,6 +514,24 @@ essenceDrain = mkCard $ do
               Right p -> DamagePlayer self p 3 False True
         void $ executeEffects [Will damageEffect, Will $ GainLife stackYou 3]
 
+ravenousRats :: Card
+ravenousRats = mkCard $ do
+    name =: Just "Ravenous Rats"
+    types =: creatureTypes [Rat]
+    pt =: Just (1, 1)
+    play =: Just playObject { manaCost = Just [Nothing, Just Black] }
+    triggeredAbilities =: onSelfETB ravenousRatsTrigger
+  where
+    ravenousRatsTrigger _rSelf you = do
+      opp <- askTarget you (targetOpponent you)
+      mkTargetTrigger you opp $ \o -> do
+        oppHand <- IdList.toList <$> view (asks (hand . player o))
+        let choices = map (makeChoice o) oppHand
+        (someRef, obj) <- askChooseCard o choices
+        void $ executeEffect $ WillMoveObject (Just someRef) (Graveyard o) obj
+    makeChoice opp (cardId, obj) = let someRef = (Some (Hand opp), cardId)
+                               in  (someRef, (someRef, obj))
+
 tormentedSoul :: Card
 tormentedSoul = mkCard $ do
     name =: Just "Tormented Soul"

--- a/Magic/src/Magic/Events.hs
+++ b/Magic/src/Magic/Events.hs
@@ -12,6 +12,7 @@ module Magic.Events (
     shuffleIntoLibrary,
     searchCard,
     askYesNo,
+    askChooseCard,
 
     executeEffects, executeEffect, will,
     tick
@@ -22,6 +23,7 @@ import Magic.Core
 import Magic.Types
 import qualified Magic.IdList as IdList
 
+import Control.Arrow (first)
 import Data.Function (on)
 import Data.Functor (void)
 import Data.List (nub, nubBy)
@@ -98,6 +100,11 @@ askYesNo :: PlayerRef -> Text -> Magic Bool
 askYesNo p txt = askQuestion p (AskChoice (Just txt) choices)
   where
     choices = [(ChoiceYesNo True, True), (ChoiceYesNo False, False)]
+
+askChooseCard :: PlayerRef -> [(SomeObjectRef, a)] -> Magic a
+askChooseCard p cards = askQuestion p (AskChoice Nothing choices)
+  where
+    choices = map (first ChoiceCard) cards
 
 -- EXECUTING EFFECTS
 


### PR DESCRIPTION
This commit also adds a helper function for asking the player to choose a card from a set of cards. This function should be general enough to be used also for situations like `Take the top 3 cards from your library, choose a card, and put it in your hand. ...`

I'm not sure whether the type of `askChooseCard` shouldn't rather be: 

``` haskell
askChooseCard :: PlayerRef -> [(SomeObjectRef, a)] -> Magic (SomeObjectRef, a)
```

(ie. always returning the full choice). But this can be changed if we see the need upon implementing further choice cards.
