### PR TITLE
Angelic Benediction: Adhere to the 'may' in the card text.

### DIFF
--- a/Magic-Cards/src/Magic/M13.hs
+++ b/Magic-Cards/src/Magic/M13.hs
@@ -85,7 +85,9 @@ angelicBenediction = mkCard $ do
     mkTapTriggerObject :: PlayerRef -> Magic ()
     mkTapTriggerObject p = do
         ts <- askTarget p targetCreature
-        mkTargetTrigger p ts (will . TapPermanent)
+        mkTargetTrigger p ts $ \t -> do
+          shouldTap <- askYesNo p "Do you want to tap target creature?"
+          when shouldTap $ will (TapPermanent t)
 
 attendedKnight :: Card
 attendedKnight = mkCard $ do
@@ -364,8 +366,7 @@ warPriestOfThune = mkCard $ do
       ench <- askTarget you targetEnchantment
       mkTargetTrigger you ench $ \ref -> do
         shouldDestroy <- askYesNo you "Destroy target enchantment?"
-        when shouldDestroy $
-          will $ DestroyPermanent ref True
+        when shouldDestroy $ will (DestroyPermanent ref True)
 
 
 -- BLUE


### PR DESCRIPTION
The card text says "you may tap target creature", but the implementation
would always result in tapping the  target creature. This can make a
difference if only Angelic Benediction and Guardian Lions are on the
battlefield, Guardian Lions attacks, yet you want to keep it untapped (eg. for blocking potential opponent's creatures with Haste).
